### PR TITLE
SAN-8968: Scoped storage support

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -120,7 +120,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private String generateTempFile() {
       // Returns the path to the scoped storage (app specific directory).
       // This is needed to support the storage changes introduced with API level 29/30.
-      return "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".m4a";;
+      return "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".m4a";
     }
 
     /**

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -120,7 +120,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private String generateTempFile() {
       // Returns the path to the scoped storage (app specific directory).
       // This is needed to support the storage changes introduced with API level 29/30.
-      return "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".m4a";
+      return handler.cordova.getActivity().getCacheDir().getPath() + "/tmprecording-" + System.currentTimeMillis() + ".m4a";
     }
 
     /**

--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -118,13 +118,9 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     }
 
     private String generateTempFile() {
-      String tempFileName = null;
-      if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-          tempFileName = Environment.getExternalStorageDirectory().getAbsolutePath() + "/tmprecording-" + System.currentTimeMillis() + ".m4a";
-      } else {
-          tempFileName = "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".m4a";
-      }
-      return tempFileName;
+      // Returns the path to the scoped storage (app specific directory).
+      // This is needed to support the storage changes introduced with API level 29/30.
+      return "/data/data/" + handler.cordova.getActivity().getPackageName() + "/cache/tmprecording-" + System.currentTimeMillis() + ".m4a";;
     }
 
     /**


### PR DESCRIPTION
- This returns the path to the scoped storage when the temp file is created. Previously it was not scoped to the app specific directory: `storage/emulated/0/{temp-file-name}.m4a`. After the change only the scoped storage file path is returned: `data/data/com.pacificalabs.pacifica/cache/{temp-file-name}.m4a`
- Needed to support the storage changes introduced with API level 29/30 and remove the problematic `requestLegacyExternalStorage` from the config.