### PR TITLE
Fix issue with pause/record saving only the first recording

### DIFF
--- a/src/android/AudioPlayer.java
+++ b/src/android/AudioPlayer.java
@@ -120,7 +120,7 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
     private String generateTempFile() {
       // Returns the path to the scoped storage (app specific directory).
       // This is needed to support the storage changes introduced with API level 29/30.
-      return handler.cordova.getActivity().getCacheDir().getPath() + "/tmprecording-" + System.currentTimeMillis() + ".m4a";
+      return handler.cordova.getActivity().getCacheDir().getPath() + "/tmprecording-" + System.currentTimeMillis() + ".3gp";
     }
 
     /**
@@ -165,12 +165,9 @@ public class AudioPlayer implements OnCompletionListener, OnPreparedListener, On
             this.recorder = new MediaRecorder();
             this.recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
 
-            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
+            this.recorder.setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS);
             this.recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
 
-            this.recorder.setAudioChannels(1); // single channel
-            this.recorder.setAudioSamplingRate(44100); // 44.1 kHz for decent sound, similar to stock iOS media plugin
-            this.recorder.setAudioEncodingBitRate(32000); // low bit rate
             this.tempFile = generateTempFile();
 
             this.recorder.setOutputFile(this.tempFile);


### PR DESCRIPTION
This reverts part of https://github.com/sanvello/cordova-plugin-media/commit/5e3d3e192066ecd4cc437cca2175e3aa596465cb#diff-ce0432e5df23db484d847768e8c572c43242610e35fada3f6712a0204f355924 due to merging issues with multiple tracks. Saving as ARM is still sound.